### PR TITLE
CMake: fix boost system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ set(PKG_CONFIG_EXTRA "qtversion=${HPP_GUI_QTVERSION}")
 set(PACKAGE_EXTRA_MACROS "set(HPP_GUI_QTVERSION ${HPP_GUI_QTVERSION})")
 
 # Search for Boost.
-add_project_dependency(Boost REQUIRED COMPONENTS thread regex system)
+add_project_dependency(Boost REQUIRED COMPONENTS thread regex)
 
 add_project_dependency("coal")
 add_project_dependency("hpp-manipulation-corba")

--- a/flake.lock
+++ b/flake.lock
@@ -97,11 +97,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1780389887,
-        "narHash": "sha256-c8XjwT8+oYdQ7BjuzUCLBqktpC1jvrC+pKDt71KYF4M=",
+        "lastModified": 1780737291,
+        "narHash": "sha256-X/NV78229FRopX6lqV2r/e0zS602Gp0kmUyp4lA/3iI=",
         "owner": "gepetto",
         "repo": "flakoboros",
-        "rev": "a1ff90acc5c0abe2a36b6384a55db5320792c887",
+        "rev": "325b46e60bf77a5b10929d94381430a390ec4843",
         "type": "github"
       },
       "original": {
@@ -148,11 +148,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1780752087,
-        "narHash": "sha256-VHXM0jPFSScSI15+lYpxPR8f2jqtQOQ13PqVI6UkRmY=",
+        "lastModified": 1780851304,
+        "narHash": "sha256-J9gvQIWdUFcBOwP0/2BnLkRIx+htvgd5F8SNROltZTM=",
         "owner": "gepetto",
         "repo": "gazebros2nix",
-        "rev": "8eb92db826f038627698a0f9ba4a3aca0a8a18d0",
+        "rev": "8d51270e902f551389a69aea2e060eb9394645f5",
         "type": "github"
       },
       "original": {
@@ -199,11 +199,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780799782,
-        "narHash": "sha256-tWr+bDnRenVumPTPWLlmKcpMKgizAy3kYf2H5K0u7So=",
+        "lastModified": 1780853277,
+        "narHash": "sha256-VGhvCn8h9U1kRyys2yTYBSRvENzXVn1JscCNTNA8v9k=",
         "owner": "gepetto",
         "repo": "nix",
-        "rev": "c7d5345af56e214ae7d0e355d1939edf612719d3",
+        "rev": "852eb18d8c26fcc775e57c1bb8a7f6b7adff922d",
         "type": "github"
       },
       "original": {
@@ -265,11 +265,11 @@
         "rosdistro": "rosdistro"
       },
       "locked": {
-        "lastModified": 1780387251,
-        "narHash": "sha256-VQpPVKWmb3y1jwc4AUk/V03UlD/7pWfFkjx9Ok8RcUQ=",
+        "lastModified": 1780736467,
+        "narHash": "sha256-Z+2rqsfRTsbt84tcmLBPawHekPU2yaEhsr/inJ2Vb5c=",
         "owner": "lopsided98",
         "repo": "nix-ros-overlay",
-        "rev": "28c809da49349cb7852194729e75ea54ba794cbb",
+        "rev": "58ed8bba49e54700448cddd05c26fd3c743909e3",
         "type": "github"
       },
       "original": {
@@ -402,11 +402,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778901413,
-        "narHash": "sha256-GSKXTAnFqRAMlZkJrIPcQMYf+lpMr66K3i60mB9STvc=",
+        "lastModified": 1780416763,
+        "narHash": "sha256-rRK3IFixgsrK6S3e14Xz9HAZm7+kMAIl3oi5zZlcwYI=",
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
-        "rev": "a228447c3e179d477c1b6246ef3efa8cfe3c469a",
+        "rev": "ad83f1ead0e78e57b188f35cb57298affb06fc5f",
         "type": "github"
       },
       "original": {
@@ -423,11 +423,11 @@
     "rosdistro": {
       "flake": false,
       "locked": {
-        "lastModified": 1780067887,
-        "narHash": "sha256-zb6ubdTFku4W8Mjb651VWJL1tWBP6BJg0iXcKypT29M=",
+        "lastModified": 1780665549,
+        "narHash": "sha256-QzobMKNpcpS4uWETzPxXkt0F66Sji15N+xsK1JcEWDU=",
         "owner": "ros",
         "repo": "rosdistro",
-        "rev": "1c698d63a1a2d31dd24502a41bb1139eeb00e876",
+        "rev": "bcec45c05427f0ad6860cb323695995d8cb1e4bd",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,7 @@
       { lib, ... }:
       {
         overrideAttrs.hpp-gui = {
+          patches = [ ]; # https://github.com/Gepetto/flakoboros/issues/62
           src = lib.fileset.toSource {
             root = ./.;
             fileset = lib.fileset.unions [

--- a/plugins/coal/CMakeLists.txt
+++ b/plugins/coal/CMakeLists.txt
@@ -35,6 +35,5 @@ gepetto_gui_plugin(
   gepetto-viewer-corba::gepetto-viewer-corba
   Boost::thread
   Boost::regex
-  Boost::system
   PKG_CONFIG_DEPENDENCIES
 )

--- a/plugins/hppcorbaserverplugin/CMakeLists.txt
+++ b/plugins/hppcorbaserverplugin/CMakeLists.txt
@@ -32,5 +32,4 @@ gepetto_gui_plugin(
   "gepetto-viewer-corba::gepetto-viewer-corba"
   "Boost::thread"
   "Boost::regex"
-  "Boost::system"
 )

--- a/plugins/hppmanipulationwidgetsplugin/CMakeLists.txt
+++ b/plugins/hppmanipulationwidgetsplugin/CMakeLists.txt
@@ -38,5 +38,4 @@ gepetto_gui_plugin(
   "gepetto-viewer-corba::gepetto-viewer-corba"
   "Boost::thread"
   "Boost::regex"
-  "Boost::system"
 )

--- a/plugins/hppwidgetsplugin/CMakeLists.txt
+++ b/plugins/hppwidgetsplugin/CMakeLists.txt
@@ -69,7 +69,6 @@ gepetto_gui_plugin(
   LINK_DEPENDENCIES
   "Boost::thread"
   "Boost::regex"
-  "Boost::system"
   "hpp-corbaserver::hpp-corbaserver"
   "gepetto-viewer-corba::gepetto-viewer-corba"
 )


### PR DESCRIPTION
This fix for boost >= 1.89:
```cmake
CMake Error at /nix/store/v2i1hgv567g3v91im5x4g5bff52143i0-cmake-4.1.2/share/cmake-4.1/Modules/FindPackageHandleStandardArgs.cmake:227 (message):
  Could NOT find Boost (missing: system) (found version "1.89.0")
Call Stack (most recent call first):
  /nix/store/v2i1hgv567g3v91im5x4g5bff52143i0-cmake-4.1.2/share/cmake-4.1/Modules/FindPackageHandleStandardArgs.cmake:591 (_FPHSA_FAILURE_MESSAGE)
  /nix/store/v2i1hgv567g3v91im5x4g5bff52143i0-cmake-4.1.2/share/cmake-4.1/Modules/FindBoost.cmake:2437 (find_package_handle_standard_args)
  /nix/store/kg1az2acy9b7jgicxgh8xqx5xgh5r2d0-jrl-cmakemodules-1.1.2/share/jrl-cmakemodules/package-config.cmake:114 (find_package)
  CMakeLists.txt:118 (add_project_dependency)

-- Configuring incomplete, errors occurred!
```

boost system has been header only since release 1.69 (December 5, 2018), and a useless stub was provided instead.

in 1.89 (August 6, 2025), that stub was removed, so CMake fail if we require it.

ref. https://www.boost.org/doc/libs/latest/libs/system/doc/html/system.html#changes_in_boost_1_89